### PR TITLE
Update p1walk.R

### DIFF
--- a/p1walk.R
+++ b/p1walk.R
@@ -641,12 +641,16 @@ Get.Bidirected.Piece <- function(b) {
 	return(Get.Directed.Piece(b.directed))
 }
  #######################################################################
-# Bipartite.Walk														#
+# Bipartite.Walk														                          #
 # Given a (randomized) list of edges (edges.to.remove) return a list 	#
-# of edges (edges.to.add) that complete an even closed walk by 			#
-# connecting the endpoints of successive edges.							#
- #######################################################################
-Bipartite.Walk <- function(edges.to.remove) {
+# of edges (edges.to.add) that complete an even closed walk by 			  #
+# connecting the endpoints of successive edges.							          #
+# This can be thought of as an operation on the parameter graph       #
+# The simple optional input simpleOnly makes sures only squarefree    #
+# move are produced.                                                  #
+# multiplicity.bound TODO.					#
+#######################################################################
+Bipartite.Walk <- function(edges.to.remove, simple.only=TRUE, multiplicity.bound=NULL) {
 	#connect head of (i+1)st edge to tail of ith edge to complete a walk:
 	num.edges = nrow(edges.to.remove)
 	edges.to.add = c()
@@ -655,9 +659,18 @@ Bipartite.Walk <- function(edges.to.remove) {
 	}
 	edges.to.add = c(edges.to.add, edges.to.remove[1, 1], edges.to.remove[num.edges, 
 		2])
-	# Ensure that edges.to.add form no loops or multiple edges
-	if (!is.simple(graph(edges.to.add))) 
-		return(NULL)
+  if (simple.only){
+  	# Ensure that edges.to.add form no loops or multiple edges
+  	if (!is.simple(graph(edges.to.add))) 
+	  	return(NULL)
+  }
+  if (multiplicity.bound!=NULL){
+    #Check that produced edges satisfy given multiplicity bound.
+    print("TODO: multiplicity.bound")
+    # numvertices = find number of vertices from multiplicity.bound
+    # if all(count.multiple(graph( edges.to.add),n=numvertices)>multiplicity.bound)
+    # return(NULL)
+  }     
 	return(edges.to.add)
 }
 #######################################################################


### PR DESCRIPTION
Added option simple.only and stub for multiplicity.bound to method bipartite.walk to allow for edges with multiplicities and loops to be introduced.
